### PR TITLE
fix bitwise opeator instead of not in lesson 2

### DIFF
--- a/Chapter02/Chapter_02.ipynb
+++ b/Chapter02/Chapter_02.ipynb
@@ -550,7 +550,7 @@
    "outputs": [],
    "source": [
     "internal = [e for e in G.edges if G.edges[e][\"internal\"]]\n",
-    "external = [e for e in G.edges if ~G.edges[e][\"internal\"]]"
+    "external = [e for e in G.edges if not G.edges[e][\"internal\"]]"
    ]
   },
   {


### PR DESCRIPTION
Bitwise operator is not a Boolean operator si it returns -2 instead of False.

Pedagogical alternative to highlight the notion of complementarity :
[_ for _ in G.edges if _ not in internal]